### PR TITLE
Set ToastrOptions as variable

### DIFF
--- a/src/Elmish.Toastr.fs
+++ b/src/Elmish.Toastr.fs
@@ -157,7 +157,8 @@ module Toastr =
     [<Emit("Object.assign({}, $0, $1)")>]
     let private mergeObjects x y = jsNative
     
-    let mutable private options : ToastrOptions =  import "options" "toastr"
+    let private optionsImport : ToastrOptions =  import "options" "toastr"
+    let mutable private options : ToastrOptions = optionsImport
     
     /// Overrides global options
     let overrideOptions (opts: ToastrOptions) : unit = 


### PR DESCRIPTION
Hi,

we are currently in the progress of migrating from webpack to vite.  We noticed an error popping up when starting vite as a dev server, complaining that it can't set `Toast_options` because it's a constant:

```
  ✘ [ERROR] Cannot assign to "Toastr_options" because it is a constant

    fable_modules/Elmish.Toastr.2.1.0/Elmish.Toastr.fs.js:162:4:
      162 │     Toastr_options = (Object.assign({}, Toastr_options, opts));
          ╵     ~~~~~~~~~~~~~~

  The symbol "Toastr_options" was declared a constant here:

    fable_modules/Elmish.Toastr.2.1.0/Elmish.Toastr.fs.js:156:13:
      156 │ export const Toastr_options = options_1;
          ╵              ~~~~~~~~~~~~~~
```

I created a minimal example here: https://github.com/rheinspree/vite-toastr

Just run `npm install`, `dotnet fable` and `npx vite serve` and it will show the error.

---

The culprit seems to be this line `let mutable private options : ToastrOptions =  import "options" "toastr"`. Despite being `mutable` the import statement creates a constant when being compiled by fable: `export const Toastr_options = options_1` (https://fable.io/docs/javascript/features.html#import-1)

My solution would be to assign the import to `optionsImport` and assign that to the original `options`. This creates the following JavaScript:
```js
export const Toastr_optionsImport = options_1;
let Toastr_options = Toastr_optionsImport;
```
I'm not deep into fable nor toastr so I'm not sure if that's a viable solution or if there are any undesired side effects.

--- 

The error never occurred with webpack nor vite build, probably due to tree shaking.